### PR TITLE
Fixed some typos and changed function for integer division

### DIFF
--- a/PCA9685.py
+++ b/PCA9685.py
@@ -127,7 +127,7 @@ class PWM(object):
 
     def setup(self):
         '''Init the class with bus_number and address'''
-        self._debug_('Reseting PCA9685 MODE1 (without SLEEP) and MODE2')
+        self._debug_('Resetting PCA9685 MODE1 (without SLEEP) and MODE2')
         self.write_all_value(0, 0)
         self._write_byte_data(self._MODE2, self._OUTDRV)
         self._write_byte_data(self._MODE1, self._ALLCALL)
@@ -192,7 +192,7 @@ class PWM(object):
             for address in addresses:
                 print("  0x%s" % address)
         if "%02X" % self.address in addresses:
-            print("Wierd, I2C device is connected, Try to run the program again, If problem stills, email this information to support@sunfounder.com")
+            print("Weird, I2C device is connected, Try to run the program again, If problem persists, email this information to support@sunfounder.com")
         else:
             print("Device is missing.")
             print("Check the address or wiring of PCA9685 Server driver, or email this information to support@sunfounder.com")
@@ -242,7 +242,8 @@ class PWM(object):
 
     def map(self, x, in_min, in_max, out_min, out_max):
         '''To map the value from arange to another'''
-        return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min
+        # need to map to int to avoid returning float with Python3 division operator
+        return int((x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min)
 
     @property
     def debug(self):

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SunFounder is a technology company focused on Raspberry Pi and Arduino open sour
 This is the code for SunFounder PCA9685.
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied wa rranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 


### PR DESCRIPTION
Hello,

I made some recent modifications to this repo that could be added to the master branch.

Here is a list of the changes:

1. In file PCA9685.py
a) Fixed a typo for print statement with "Resetting"
b) Fixed typos in a print statement for the misspelling of "Weird" and changed "Stills" to "Persists"
c) Adjusted the map function to return an integer by typecasting the return value as int to avoid floating-type division for Python3
2. In the README.md file: 
a) Changed to README.md to fix "wa rranty" to "warranty" without the space

Thanks